### PR TITLE
Update the "Contribute" and "About" pages

### DIFF
--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -6,14 +6,12 @@
     %h5
       The catalogue
     %p
-      This catalogue has been developed by
+      This catalogue was originally developed in 2020 by
       %a{href: "http://www.antleaf.com"} Antleaf
       for the
       %a{href: "https://www.coar-repositories.org"} Confederation of Open Access Repositories (COAR)
       as part of the
-      %a{href: "https://educopia.org/next-generation-library-publishing/"} Next Generation Libraries Publishing project
-      and is licensed under a
-      %a{rel:"license", href: "https://creativecommons.org/licenses/by/4.0/"} Creative Commons Attribution 4.0 License
+      %a{href: "https://educopia.org/next-generation-library-publishing/"} Next Generation Libraries Publishing project.
 
     %p
       SComCat comprises a catalogue (knowledge base) of scholarly communication open technologies where the term "technologies" is defined to include software and some essential running services. The aim is to assist potential users in making decisions about which technologies they will adopt by providing an overview of the functionality, organizational models, dependencies, use of standards, and levels of adoption of each technology.
@@ -22,7 +20,8 @@
     %p
       We envision this scan as being extensible over time in order to address the evolving needs of various communities.
     %p
-      SComCat is built as <a href="https://github.com/antleaf/scomcat">open-source software</a>, licensed under an MIT License.
+      The SComCat application is <a href="https://github.com/OpenTechStrategies/scomcat">open source software</a>, licensed under an MIT License, and the data catalogue is licensed under a
+      %a{rel:"license", href: "https://creativecommons.org/licenses/by/4.0/"} Creative Commons Attribution 4.0 License.
     %p
       =link_to image_tag("Educopia_NextGen_PartnerLogoBanner_half_size.png", :id => "nglp-logo-banner"), "https://educopia.org/next-generation-library-publishing/"
     %p
@@ -50,6 +49,10 @@
     %ul
       %li Ilkay Holt, COAR
       %li Sarah Lippincott, Born-Digital
+    %h6
+      Current maintenance (since October 2022)
+    %ul
+      %li <a href="https://www.OpenTechStrategies.com/" >Open Tech Strategies</a>
 
 
 -#%h5 Experimental features

--- a/app/views/contribute/index.html.haml
+++ b/app/views/contribute/index.html.haml
@@ -1,13 +1,7 @@
 %h5 Contributing to SComCat
 
 %p
-  The Contribute section allows users of the SComCat tool to supply new entries for the SComCat Database. A team from the Next Generation Library Publishing Project (NGLP) will formally review each contribution as part of the peer-review process. New information that is approved by this team for inclusion will be incorporated in the subsequent updates to the SComCat Database.
-%p
-  The Contribute section allows the database to continue evolving in a way that respects the high standards of data gathering and evaluation that have governed the construction of the original database. When the NGLP project concludes (currently Spring 2022), this resource will transition into an appropriate longer-term home, and an Editorial Review Board will continue to serve in this capacity.
-
-%p
-  To contribute a suggestion for a new entry, or a revision for an existing entry in the SComCat Database, please use the feedback button (below, right).
-
+  The Contribute section allows users of the SComCat tool to supply new entries for the SComCat Database.  Since the conclusion of the Next Generation Library Publishing Project (NGLP) in Spring 2022, the best way to suggest new entries or updates to existing entries in SComCat is to <a href="https://github.com/OpenTechStrategies/SComCaT/issues/new" >file a ticket here</a> or <a href="https://chat.opentechstrategies.com/#narrow/stream/2-general/topic/SComCat" >mention the suggestion here</a>.  The <a href="https://www.OpenTechStrategies.com" >current maintainers</a> will respond to and review suggestions as quickly as they can.
 
 -#%p
 -#  To contribute a revision for an existing listing in the SComCat Database, please fill out the form below.


### PR DESCRIPTION
With the conclusion of the NGLP project in Spring 2022, Antleaf is no longer actively maintaining SComCat and their repository is archived; Open Tech Strategies now maintains SComCat on a semi-volunteer basis.