### PR TITLE
Use lower-case final "t" in "SComCat"

### DIFF
--- a/app/views/_shared/_head.html.haml
+++ b/app/views/_shared/_head.html.haml
@@ -1,7 +1,7 @@
 %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}
   %meta{:'http-equiv'=> "X-UA-Compatible", :content=>"IE=edge"}
   %meta{:name=>"viewport", :content=>"width=device-width, initial-scale=1"}
-  %title SComCaT
+  %title SComCat
   = csrf_meta_tags
   = csp_meta_tag
   - if !ENV['SCOMCAT_GOOGLE_ANALYTICS_CODE'].blank?


### PR DESCRIPTION
There had been inconsistent signals from upstream as to whether it's "SComCaT" or "SComCat", but the preponderance of evidence does seem to point at the latter (and there's no logical reason for the former that I can see).  I already adjusted the repository's name in the GitHub settings for our clone, excuse me I mean "fork", matching this change.